### PR TITLE
Fix IllegalStateException & Add MethodResultWrapper

### DIFF
--- a/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
+++ b/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
@@ -1,7 +1,6 @@
 package im.nfc.flutter_nfc_kit
 
 import android.app.Activity
-import android.os.Handler
 import android.nfc.NfcAdapter
 import android.nfc.NfcAdapter.*
 import android.nfc.Tag

--- a/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
+++ b/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
@@ -5,6 +5,8 @@ import android.nfc.NfcAdapter
 import android.nfc.NfcAdapter.*
 import android.nfc.Tag
 import android.nfc.tech.*
+import android.os.Handler
+import android.os.Looper
 import im.nfc.flutter_nfc_kit.ByteUtils.hexToBytes
 import im.nfc.flutter_nfc_kit.ByteUtils.toHexString
 import io.flutter.Log
@@ -36,6 +38,10 @@ class FlutterNfcKitPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {
+        handleMethodCall(call, MethodResultWrapper(result))
+    }
+
+    private fun handleMethodCall(call: MethodCall, result: MethodResultWrapper) {
         val nfcAdapter = getDefaultAdapter(activity)
 
         if (nfcAdapter?.isEnabled != true && call.method != "getNFCAvailability") {
@@ -133,7 +139,7 @@ class FlutterNfcKitPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     override fun onDetachedFromActivityForConfigChanges() {}
 
-    private fun pollTag(nfcAdapter: NfcAdapter, result: Result) {
+    private fun pollTag(nfcAdapter: NfcAdapter, result: MethodResultWrapper) {
         pending = true
 
         pollingTimeoutTask = Timer().schedule(20000) {
@@ -223,24 +229,74 @@ class FlutterNfcKitPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 type = "unknown"
                 standard = "unknown"
             }
-            activity?.runOnUiThread {
-                if (pending) {
-                    result.success(JSONObject(mapOf(
-                            "type" to type,
-                            "id" to id,
-                            "standard" to standard,
-                            "atqa" to atqa,
-                            "sak" to sak,
-                            "historicalBytes" to historicalBytes,
-                            "protocolInfo" to protocolInfo,
-                            "applicationData" to applicationData,
-                            "hiLayerResponse" to hiLayerResponse,
-                            "manufacturer" to manufacturer,
-                            "systemCode" to systemCode,
-                            "dsfId" to dsfId
-                    )).toString())
-                }
+
+            if (pending) {
+                result.success(JSONObject(mapOf(
+                    "type" to type,
+                    "id" to id,
+                    "standard" to standard,
+                    "atqa" to atqa,
+                    "sak" to sak,
+                    "historicalBytes" to historicalBytes,
+                    "protocolInfo" to protocolInfo,
+                    "applicationData" to applicationData,
+                    "hiLayerResponse" to hiLayerResponse,
+                    "manufacturer" to manufacturer,
+                    "systemCode" to systemCode,
+                    "dsfId" to dsfId
+                )).toString())
             }
         }, FLAG_READER_SKIP_NDEF_CHECK or FLAG_READER_NFC_A or FLAG_READER_NFC_B or FLAG_READER_NFC_V or FLAG_READER_NFC_F, null)
+    }
+
+    private class MethodResultWrapper internal constructor(result: MethodChannel.Result) : MethodChannel.Result {
+        private val methodResult: MethodChannel.Result
+        private val handler: Handler
+
+        init {
+            methodResult = result
+            handler = Handler(Looper.getMainLooper())
+        }
+
+        override fun success(result: Any?) {
+            handler.post(
+                object : Runnable {
+                    override fun run() {
+                        ignoreIllegalState {
+                            methodResult.success(result)
+                        }
+                    }
+                })
+        }
+
+        override fun error(errorCode: String?, errorMessage: String?, errorDetails: Any?) {
+            handler.post(
+                object : Runnable {
+                    override fun run() {
+                        ignoreIllegalState {
+                            methodResult.error(errorCode, errorMessage, errorDetails)
+                        }
+                    }
+                })
+        }
+
+        override fun notImplemented() {
+            handler.post(
+                object : Runnable {
+                    override fun run() {
+                        ignoreIllegalState {
+                            methodResult.notImplemented()
+                        }
+                    }
+                })
+        }
+
+        private fun ignoreIllegalState(fn: () -> Unit) {
+            try {
+                fn()
+            } catch (e: IllegalStateException) {
+                Log.d(TAG, "Ignoring exception: $e")
+            }
+        }
     }
 }

--- a/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
+++ b/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
@@ -21,10 +21,6 @@ import org.json.JSONObject
 import java.io.IOException
 import java.util.*
 import kotlin.concurrent.schedule
-import android.os.Looper
-
-
-
 
 
 class FlutterNfcKitPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {


### PR DESCRIPTION
This PR handles `IllegalStateException` exception by catching it (log it) and not re-throwing it . The `IllegalStateException` exception can't be caught in Flutter thus, if thrown it results in crashing the app.
It looks like sometimes the same method of class `MethodChannel.Result` (error, success, notImplemented) is being called multiple times and result is `IllegalStateException` exception being thrown. This issue could be part of Flutter plugin framework and not this plugin. See [https://github.com/flutter/flutter/issues/29092](https://github.com/flutter/flutter/issues/29092).
This PR also introduces wrapper for `MethodChannel.Result` which insures that calls to methods `error`, `success`, `notImplemented` is run on the main thread.

Background:  
From time to time I've encountered exception `flutter java.lang.IllegalStateException: Call connect() first` which chrashed the app because this exception can't be caught in Flutter. The easiest why to reproduce this is by getting `PlatformException` exception (timeout error) from plugin while polling and not calling `FlutterNfcKit.finish()` function then try to poll again. It should result in app crash due to unhandled exception: `java.lang.IllegalStateException: Reply already submitted`.

*Note: PR was tested on biometric passport.*
  