### PR TITLE
Change transceive timeout to 5 sec on Android

### DIFF
--- a/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
+++ b/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
@@ -184,6 +184,7 @@ class FlutterNfcKitPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                         standard = "ISO 14443-4 (Type A)"
                         type = "iso7816"
                         val isoDep = IsoDep.get(tag)
+                        isoDep.timeout = 5000
                         tagTechnology = isoDep
                         historicalBytes = isoDep.historicalBytes.toHexString()
                     }
@@ -208,6 +209,7 @@ class FlutterNfcKitPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                     type = "iso7816"
                     standard = "ISO 14443-4 (Type B)"
                     val isoDep = IsoDep.get(tag)
+                    isoDep.timeout = 5000
                     tagTechnology = isoDep
                     hiLayerResponse = isoDep.hiLayerResponse.toHexString()
                 } else {


### PR DESCRIPTION
This PR sets transceive timeout to 5 sec for IsoDep tag.

Background: 
On some slower smart cards transceive operations that require longer processing time e.g. `READ BINARY` can cause to prematurely end in *`tag lost`* error. Extending the timeout to 5 sec should fix this.