### PR TITLE
Fix compiling for iOS

### DIFF
--- a/ios/Classes/SwiftFlutterNfcKitPlugin.swift
+++ b/ios/Classes/SwiftFlutterNfcKitPlugin.swift
@@ -248,10 +248,10 @@ public class SwiftFlutterNfcKitPlugin: NSObject, FlutterPlugin, NFCTagReaderSess
                                 format = NFCTypeNameFormat.unknown
                             }
                             records.append(NFCNDEFPayload(
-                                format: format,
-                                type: dataWithHexString(hex: record["type"]),
-                                identifier: dataWithHexString(hex: record["identifier"]),
-                                payload: dataWithHexString(hex: record["payload"])
+                                format: format!,
+                                type: dataWithHexString(hex: record["type"] as! String),
+                                identifier: dataWithHexString(hex: record["identifier"] as! String),
+                                payload: dataWithHexString(hex: record["payload"] as! String)
                             ))
                         }
 


### PR DESCRIPTION
PR fixes unwrapping `NFCTypeNameFormat` object and castting call parameters to `String` when constructing `NFCNDEFPayload` object for `writeNDEF` command.