### PR TITLE
Downgrade androidx.core:core-ktx to 1.6.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.core:core-ktx:1.6.0'
 }


### PR DESCRIPTION
Fixing issue #55

I tried to fix the issue from app side with the following 2 solutions, but DOESN'T WORK

```groovy
 configurations.all {
   resolutionStrategy { force 'androidx.core:core-ktx:1.6.0' }
 }
android {
  defaultConfig {
    configurations.all {
      resolutionStrategy { force 'androidx.core:core-ktx:1.6.0' }
    }
  }
}
```

And

```groovy
dependencies {
  implementation('androidx.core:core-ktx') {
    version {
      strictly '1.6.0'
    }
  }
}
```