### PR TITLE
Break execution when NDEF is not writable

### DIFF
--- a/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
+++ b/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
@@ -216,6 +216,7 @@ class FlutterNfcKitPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 val ndef = ndefTechnology!!
                 if (ndef.isWritable() == false) {
                     result.error("405", "Tag not writable", null)
+                    return
                 }
                 thread {
                     try {

--- a/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
+++ b/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
@@ -79,7 +79,7 @@ class FlutterNfcKitPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             } else true
         }
 
-        val switchTechnology = { target: TagTechnology, other: TagTechnology? -> 
+        val switchTechnology = { target: TagTechnology, other: TagTechnology? ->
             if (!target.isConnected) {
                 // close previously connected technology
                 if (other !== null && other.isConnected) {
@@ -259,6 +259,7 @@ class FlutterNfcKitPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 val ndef = ndefTechnology!!
                 if (ndef.isWritable() == false) {
                     result.error("405", "Tag not writable", null)
+                    return
                 }
                 thread {
                     try {


### PR DESCRIPTION
`makeNdefReadOnly` and `writeNDEF` handler on Android kept running after threw an error related to tag is/isn't writable.
