### PR TITLE
Do no throw 500 error when reading an empty tag on iOS

### DIFF
--- a/ios/Classes/SwiftFlutterNfcKitPlugin.swift
+++ b/ios/Classes/SwiftFlutterNfcKitPlugin.swift
@@ -176,7 +176,10 @@ public class SwiftFlutterNfcKitPlugin: NSObject, FlutterPlugin, NFCTagReaderSess
                 }
                 if ndefTag != nil {
                     ndefTag!.readNDEF(completionHandler: { (msg: NFCNDEFMessage?, error: Error?) in
-                        if let error = error {
+                        if let nfcError = error as? NFCReaderError, nfcError.errorCode == 403  {
+                            // NDEF tag does not contain any NDEF message
+                            result("[]")
+                        } else if let error = error {
                             result(FlutterError(code: "500", message: "Read NDEF error", details: error.localizedDescription))
                         } else if let msg = msg {
                             var records: [[String: Any]] = []
@@ -211,7 +214,7 @@ public class SwiftFlutterNfcKitPlugin: NSObject, FlutterPlugin, NFCTagReaderSess
                             let jsonString = String(data: jsonData, encoding: .utf8)
                             result(jsonString)
                         } else {
-                            result("[]")
+                            result(FlutterError(code: "500", message: "Impossible branch reached", details: nil))
                         }
                     })
                 } else {

--- a/ios/Classes/SwiftFlutterNfcKitPlugin.swift
+++ b/ios/Classes/SwiftFlutterNfcKitPlugin.swift
@@ -211,7 +211,7 @@ public class SwiftFlutterNfcKitPlugin: NSObject, FlutterPlugin, NFCTagReaderSess
                             let jsonString = String(data: jsonData, encoding: .utf8)
                             result(jsonString)
                         } else {
-                            result(FlutterError(code: "500", message: "Got no NDEF records", details: nil))
+                            result("[]")
                         }
                     })
                 } else {
@@ -354,8 +354,10 @@ public class SwiftFlutterNfcKitPlugin: NSObject, FlutterPlugin, NFCTagReaderSess
 
     // from NFCTagReaderSessionDelegate
     public func tagReaderSession(_: NFCTagReaderSession, didInvalidateWithError error: Error) {
+
         if result != nil {
             NSLog("Got error when reading NFC: %@", error.localizedDescription)
+
             result?(FlutterError(code: "500", message: "Invalidate session with error", details: error.localizedDescription))
             result = nil
             session = nil


### PR DESCRIPTION
Do not throw 500 when reading an empty tag. As it is impossible to distinguish it is an empty tag or something really goes wrong on flutter side.

Instead, it now returns empty array.