### PR TITLE
Make ndefCanMakeReadOnly as true and tag is writable on iOS

### DIFF
--- a/ios/Classes/SwiftFlutterNfcKitPlugin.swift
+++ b/ios/Classes/SwiftFlutterNfcKitPlugin.swift
@@ -464,6 +464,7 @@ public class SwiftFlutterNfcKitPlugin: NSObject, FlutterPlugin, NFCTagReaderSess
                         }
                         if status == NFCNDEFStatus.readWrite {
                             result["ndefWritable"] = true
+                            result["ndefCanMakeReadOnly"] = true
                         }
                         result["ndefCapacity"] = capacity
                     }


### PR DESCRIPTION
On iOS `ndefCanMakeReadOnly` is always false even `writeLock` can be called without problem