### PR TITLE
Add "iosRestartPolling" method

### DIFF
--- a/ios/Classes/SwiftFlutterNfcKitPlugin.swift
+++ b/ios/Classes/SwiftFlutterNfcKitPlugin.swift
@@ -50,6 +50,13 @@ public class SwiftFlutterNfcKitPlugin: NSObject, FlutterPlugin, NFCTagReaderSess
             } else {
                 result("not_supported")
             }
+        } else if call.method == "restartPolling" {
+            if let session = session {
+                self.result = result
+                session.restartPolling()
+            } else {
+                result(FlutterError(code: "404", message: "No active session", details: nil))
+            }
         } else if call.method == "poll" {
             if session != nil {
                 result(FlutterError(code: "406", message: "Cannot invoke poll in a active session", details: nil))

--- a/lib/flutter_nfc_kit.dart
+++ b/lib/flutter_nfc_kit.dart
@@ -343,6 +343,13 @@ class FlutterNfcKit {
     return NFCTag.fromJson(jsonDecode(data));
   }
 
+  /// Works only on iOS
+  /// Calls NFCTagReaderSession.restartPolling()
+  /// Call this if you have received "Tag connection lost" exception
+  /// This will allow to reconnect to tag without closing system popup
+  static Future<void> iosRestartPolling() async =>
+      await _channel.invokeMethod("restartPolling");
+
   /// Transceive data with the card / tag in the format of APDU (iso7816) or raw commands (other technologies).
   /// The [capdu] can be either of type Uint8List or hex string.
   /// Return value will be in the same type of [capdu].


### PR DESCRIPTION
Sometimes I'm receiving "Tag connection lost" even if tag isn't moving
And I have to execute over 400 commands in a row, so starting again or reconnecting isn't an option, since you can't get rid of all those "awesome" animation and it takes a second on each exception.
I've added `iosRestartPolling` method which calls `NFCTagReaderSession.restartPolling()` in Swift and it solves the issue for me.
I hope this will help someone else