### PR TITLE
fix: MIFARE Classic: allow sector 0 authentication

### DIFF
--- a/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
+++ b/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
@@ -309,8 +309,9 @@ class FlutterNfcKitPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                     return
                 }
                 val index = call.argument<Int>("index")!!
-                if (!(0 < index && index < mifareInfo!!.sectorCount!!)) {
-                    result.error("400", "Invalid sector index $index", null)
+                val maxSector = mifareInfo!!.sectorCount!!
+                if (index !in 0 until maxSector) {
+                    result.error("400", "Invalid sector index $index, should be in (0, $maxSector)", null)
                     return
                 }
                 val keyA = call.argument<Any>("keyA")


### PR DESCRIPTION
Due to a logic bug, authenticating sector 0 isn't currently possible.

Adapt a similar, but more robust and descriptive, range check from the readBlock method to remedy this.

fixes: #160