### PR TITLE
fix: relax android minSdkVersion and js dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 26
+        minSdkVersion 21
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   ndef: ^0.3.3
   convert: ^3.1.1
   logging: ^1.2.0
-  js: ^0.7.1
+  js: ^0.6.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Lowered the minSdkVersion for android to match the flutter minSdk.
The minSdk was falsely lowered to fix some gradle build error but I am using my fork with no issues.
Also lowered js dependency to play nicely with other flutter packages.