### PR TITLE
Enable read & write block for iOS MIFARE Classic, Updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This plugin's functionalities include:
   * ISO 18092 (NFC-F / FeliCa)
   * ISO 15963 (NFC-V)
 * R/W block / page / sector level data of tags complying with:
-  * MIFARE Classic / Ultralight (Android only)
+  * MIFARE Classic / Ultralight (Android only, MIFARE Classic Read block for iOS)
   * ISO 15693 (iOS only)
 * transceive raw commands with tags / cards complying with:
   * ISO 7816 Smart Cards (layer 4, in APDUs)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This plugin's functionalities include:
   * ISO 18092 (NFC-F / FeliCa)
   * ISO 15963 (NFC-V)
 * R/W block / page / sector level data of tags complying with:
-  * MIFARE Classic / Ultralight (Android only, MIFARE Classic Read block for iOS)
+  * MIFARE Classic / Ultralight (Android only, MIFARE Classic Read & Write block for iOS)
   * ISO 15693 (iOS only)
 * transceive raw commands with tags / cards complying with:
   * ISO 7816 Smart Cards (layer 4, in APDUs)

--- a/ios/flutter_nfc_kit/Sources/flutter_nfc_kit/FlutterNfcKitPlugin.swift
+++ b/ios/flutter_nfc_kit/Sources/flutter_nfc_kit/FlutterNfcKitPlugin.swift
@@ -210,8 +210,8 @@ public class FlutterNfcKitPlugin: NSObject, FlutterPlugin, NFCTagReaderSessionDe
                     let blockNumber = arguments["index"] as! Int
                     tag.extendedReadSingleBlock(requestFlags: RequestFlag(rawValue: rawFlags), blockNumber: blockNumber, completionHandler: handler)
                 }
-            } else {
-               if case let .miFare(tag) = tag {
+            }
+            else if case let .miFare(tag) = tag {
                             let blockNumber = arguments["index"] as! UInt8
                             let commandPacket = Data([0x30, blockNumber]) //0x30 is the MIFARE Classic Read Command.
                              tag.sendMiFareCommand(commandPacket: commandPacket) { (data, error) in
@@ -221,11 +221,9 @@ public class FlutterNfcKitPlugin: NSObject, FlutterPlugin, NFCTagReaderSessionDe
                                      result(data)
                                  }
                              }
-                        }
-                else
-                {
-                  result(FlutterError(code: "405", message: "readBlock not supported on this type of card", details: nil))
-                }
+            }             
+            else {
+                result(FlutterError(code: "405", message: "readBlock not supported on this type of card", details: nil))
             }
         } else if call.method == "writeBlock" {
             let arguments = call.arguments as! [String : Any?]
@@ -247,8 +245,8 @@ public class FlutterNfcKitPlugin: NSObject, FlutterPlugin, NFCTagReaderSessionDe
                     let blockNumber = arguments["index"] as! Int
                     tag.extendedWriteSingleBlock(requestFlags: RequestFlag(rawValue: rawFlags), blockNumber: blockNumber, dataBlock: data, completionHandler: handler)
                 }
-            } else {
-                if case let .miFare(tag) = tag {
+            } 
+            else if case let .miFare(tag) = tag {
                    let blockNumber = arguments["index"] as! UInt8
                    let writeCommand = Data([0xA2, blockNumber]) + data  //0xA2 is the MIFARE Classic Write Command to write single block.
                    tag.sendMiFareCommand(commandPacket: writeCommand) { (response, error) in
@@ -260,11 +258,9 @@ public class FlutterNfcKitPlugin: NSObject, FlutterPlugin, NFCTagReaderSessionDe
                             result(nil)
                          }
                    }
-                }
-                else
-                {
+            }            
+            else {
                     result(FlutterError(code: "405", message: "writeBlock not supported on this type of card", details: nil))
-                }
             }
         } else if call.method == "readNDEF" {
             if tag != nil {

--- a/ios/flutter_nfc_kit/Sources/flutter_nfc_kit/FlutterNfcKitPlugin.swift
+++ b/ios/flutter_nfc_kit/Sources/flutter_nfc_kit/FlutterNfcKitPlugin.swift
@@ -211,7 +211,21 @@ public class FlutterNfcKitPlugin: NSObject, FlutterPlugin, NFCTagReaderSessionDe
                     tag.extendedReadSingleBlock(requestFlags: RequestFlag(rawValue: rawFlags), blockNumber: blockNumber, completionHandler: handler)
                 }
             } else {
-                result(FlutterError(code: "405", message: "readBlock not supported on this type of card", details: nil))
+               if case let .miFare(tag) = tag {
+                            let blockNumber = arguments["index"] as! UInt8
+                            let commandPacket = Data([0x30, blockNumber]) //0x30 is the MIFARE Classic Read Command.
+                             tag.sendMiFareCommand(commandPacket: commandPacket) { (data, error) in
+                                 if let error = error {
+                                    result(FlutterError(code: "405", message: "Something is wrong", details: nil))
+                                 } else {
+                                     result(data)
+                                 }
+                             }
+                        }
+                else
+                {
+                  result(FlutterError(code: "405", message: "readBlock not supported on this type of card", details: nil))
+                }
             }
         } else if call.method == "writeBlock" {
             let arguments = call.arguments as! [String : Any?]


### PR DESCRIPTION
iOS swift plugin edit to support read & write block for iOS MIFARE Classic.

Note - 0x30 is the MIFARE Classic Read Command. 0xA2 is the MIFARE Classic Write Command to write single block.