### PR TITLE
Fix: NFC Handler dead thread issue on Android SDK 35

### DIFF
--- a/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
+++ b/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
@@ -89,9 +89,12 @@ class FlutterNfcKitPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                     }
                 }
             }
-            if (!nfcHandler.post(handledFn)) {
-                result.error("500", "Failed to post job to NFC Handler thread.", null)
+            val looperThread = nfcHandler.looper?.thread
+            if (looperThread == null || !looperThread.isAlive) {
+                val thread = HandlerThread("FlutterNfcKit").apply { start() }
+                nfcHandler = Handler(thread.looper)
             }
+            nfcHandler.post(handledFn)
         }
 
         private fun parseTag(tag: Tag): String {

--- a/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
+++ b/android/src/main/kotlin/im/nfc/flutter_nfc_kit/FlutterNfcKitPlugin.kt
@@ -94,7 +94,10 @@ class FlutterNfcKitPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 val thread = HandlerThread("FlutterNfcKit").apply { start() }
                 nfcHandler = Handler(thread.looper)
             }
-            nfcHandler.post(handledFn)
+            val posted = nfcHandler.post(handledFn)
+            if (!posted) {
+                result.error("500", "Failed to post job to NFC Handler thread.", null)
+            }
         }
 
         private fun parseTag(tag: Tag): String {


### PR DESCRIPTION
**This PR fixes an issue where the NFC handler thread could be dead, causing IllegalStateException: Handler sending message to a dead thread errors when polling or transceiving NFC tags on Android.**

**Root Cause:**
After upgrading the Android SDK (34 → 35) and Gradle (7 → 8), the existing NFC handler could sometimes be uninitialised or dead at the time of posting a job, leading to crashes.

**Solution:**
Check if the NFC handler thread exists and is alive before posting a job.
If not, create a new HandlerThread and assign a new Handler to ensure all NFC operations run on a valid thread.
Post the NFC job only after the handler is guaranteed to be alive.
